### PR TITLE
Make gem compatible with latest version of Rubygems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ pkg
 .*.sw?
 Gemfile.lock
 *.gem
+.bundle
+vendor

--- a/levenshtein-ffi.gemspec
+++ b/levenshtein-ffi.gemspec
@@ -48,27 +48,18 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<levenshtein-ffi>.freeze, [">= 0"])
       s.add_development_dependency(%q<rspec>.freeze, ["~> 2.99"])
       s.add_development_dependency(%q<jeweler>.freeze, ["~> 2.0"])
       s.add_runtime_dependency(%q<ffi>.freeze, ["~> 1.9"])
-      s.add_development_dependency(%q<rspec>.freeze, ["~> 2.99"])
-      s.add_development_dependency(%q<jeweler>.freeze, ["~> 2.0"])
     else
-      s.add_dependency(%q<levenshtein-ffi>.freeze, [">= 0"])
       s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
       s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
       s.add_dependency(%q<ffi>.freeze, ["~> 1.9"])
-      s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
-      s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
     end
   else
-    s.add_dependency(%q<levenshtein-ffi>.freeze, [">= 0"])
     s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
     s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
     s.add_dependency(%q<ffi>.freeze, ["~> 1.9"])
-    s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
-    s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
   end
 end
 

--- a/levenshtein-ffi.gemspec
+++ b/levenshtein-ffi.gemspec
@@ -6,17 +6,19 @@
 # stub: ext/levenshtein/extconf.rb
 
 Gem::Specification.new do |s|
-  s.name = "levenshtein-ffi"
+  s.name = "levenshtein-ffi".freeze
   s.version = "1.1.0"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["David Balatero"]
-  s.date = "2014-08-11"
-  s.description = "Provides a fast, cross-Ruby implementation of the levenshtein distance algorithm."
-  s.email = "dbalatero@gmail.com"
-  s.extensions = ["ext/levenshtein/extconf.rb"]
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["David Balatero".freeze]
+  s.date = "2023-09-14"
+  s.description = "Provides a fast, cross-Ruby implementation of the levenshtein distance algorithm.".freeze
+  s.email = "dbalatero@gmail.com".freeze
+  s.extensions = ["ext/levenshtein/extconf.rb".freeze]
   s.extra_rdoc_files = [
+    "CHANGELOG.markdown",
+    "LICENSE",
     "README.markdown"
   ]
   s.files = [
@@ -24,6 +26,7 @@ Gem::Specification.new do |s|
     ".travis.yml",
     "CHANGELOG.markdown",
     "Gemfile",
+    "LICENSE",
     "README.markdown",
     "Rakefile",
     "VERSION",
@@ -37,27 +40,35 @@ Gem::Specification.new do |s|
     "spec/levenshtein_spec.rb",
     "spec/spec_helper.rb"
   ]
-  s.homepage = "http://github.com/dbalatero/levenshtein-ffi"
-  s.license = "BSD 2-Clause"
-  s.rubygems_version = "2.2.2"
-  s.summary = "An FFI version of the levenshtein gem."
+  s.homepage = "http://github.com/dbalatero/levenshtein-ffi".freeze
+  s.rubygems_version = "3.0.3.1".freeze
+  s.summary = "An FFI version of the levenshtein gem.".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<ffi>, ["~> 1.9"])
-      s.add_development_dependency(%q<rspec>, ["~> 2.99"])
-      s.add_development_dependency(%q<jeweler>, ["~> 2.0"])
+      s.add_runtime_dependency(%q<levenshtein-ffi>.freeze, [">= 0"])
+      s.add_development_dependency(%q<rspec>.freeze, ["~> 2.99"])
+      s.add_development_dependency(%q<jeweler>.freeze, ["~> 2.0"])
+      s.add_runtime_dependency(%q<ffi>.freeze, ["~> 1.9"])
+      s.add_development_dependency(%q<rspec>.freeze, ["~> 2.99"])
+      s.add_development_dependency(%q<jeweler>.freeze, ["~> 2.0"])
     else
-      s.add_dependency(%q<ffi>, ["~> 1.9"])
-      s.add_dependency(%q<rspec>, ["~> 2.99"])
-      s.add_dependency(%q<jeweler>, ["~> 2.0"])
+      s.add_dependency(%q<levenshtein-ffi>.freeze, [">= 0"])
+      s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
+      s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
+      s.add_dependency(%q<ffi>.freeze, ["~> 1.9"])
+      s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
+      s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
     end
   else
-    s.add_dependency(%q<ffi>, ["~> 1.9"])
-    s.add_dependency(%q<rspec>, ["~> 2.99"])
-    s.add_dependency(%q<jeweler>, ["~> 2.0"])
+    s.add_dependency(%q<levenshtein-ffi>.freeze, [">= 0"])
+    s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
+    s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
+    s.add_dependency(%q<ffi>.freeze, ["~> 1.9"])
+    s.add_dependency(%q<rspec>.freeze, ["~> 2.99"])
+    s.add_dependency(%q<jeweler>.freeze, ["~> 2.0"])
   end
 end
 

--- a/lib/levenshtein.rb
+++ b/lib/levenshtein.rb
@@ -4,10 +4,10 @@ module Levenshtein
   class << self
     extend FFI::Library
 
-    # Try loading in order.
-    library = File.dirname(__FILE__) + "/../ext/levenshtein/levenshtein"
-    candidates = ['.bundle', '.so', '.dylib', ''].map { |ext| library + ext }
-    ffi_lib(candidates)
+    library = "levenshtein.#{RbConfig::MAKEFILE_CONFIG['DLEXT']}"
+    candidates = ["#{__FILE__}/..", "#{__FILE__}/../../ext/levenshtein"]
+    candidates.unshift(Gem.loaded_specs['levenshtein-ffi'].extension_dir) if Gem.loaded_specs['levenshtein-ffi']
+    ffi_lib(candidates.map { |dir| File.expand_path(library, dir) })
 
     # Safe version of distance, checks that arguments are really strings.
     def distance(str1, str2)


### PR DESCRIPTION
This PR applies the changes https://github.com/dbalatero/levenshtein-ffi/pull/11 onto our own fork of the library.